### PR TITLE
Update blue_heron constraint to ~> 0.2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule BlueHeronTransportUSB.MixProject do
   defp deps do
     [
       # {:blue_heron, path: "../blue_heron"},
-      {:blue_heron, "~> 0.1.0"},
+      {:blue_heron, "~> 0.3.0"},
       {:elixir_make, "~> 0.6.0", runtime: false},
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},
       {:dialyxir, "~> 1.0.0", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "blue_heron": {:hex, :blue_heron, "0.1.0", "eba980dc10030f5c66e1ec92e693524d9aa92a0c7b3acec7baa19278efa1676d", [:mix], [{:ex_bin, "~> 0.4", [hex: :ex_bin, repo: "hexpm", optional: false]}], "hexpm", "b2600081d8e05d3d56748401e53c06eab888591b4289f47a36f746efed9e6b2b"},
+  "blue_heron": {:hex, :blue_heron, "0.3.0", "a9e1e8b4b34c2506f9a5e7b073a0e44cba2a6c2070f127eea10ad132c9c90d3c", [:mix], [], "hexpm", "190887a090fc8af7f9f6a6d2183dee6877b4a43a42d45315ce3d6d575ef0ef8e"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
   "credo": {:hex, :credo, "1.4.0", "92339d4cbadd1e88b5ee43d427b639b68a11071b6f73854e33638e30a0ea11f5", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "1fd3b70dce216574ce3c18bdf510b57e7c4c85c2ec9cad4bff854abaf7e58658"},
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},


### PR DESCRIPTION
It doesn't look like there's any breaking changes, although I haven't tested this locally yet
